### PR TITLE
removed unnecessary and not very useful 'type' column from moto table

### DIFF
--- a/db/migrate/20201117033947_remove_type_from_motorcycles.rb
+++ b/db/migrate/20201117033947_remove_type_from_motorcycles.rb
@@ -1,0 +1,5 @@
+class RemoveTypeFromMotorcycles < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :motorcycles, :type, :string
+  end
+end


### PR DESCRIPTION
Decided that the 'type' category is unnecessary. A lot of motorcycles are hard to place in one category. Also riders know brands well and the types of bikes they produce, so the renter is more likely to search by brand anyways rather than type.